### PR TITLE
feat(message.attachements): allow send message with attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ client.send(
         },
         components: [], // Message components (Not optional, must be an array, can be unset for default) (Default empty array)
         stickers: [], // Stickers to go with your message (Not optional, must be an array, can be unset for default) (Default empty array)
+        attachments: [ // Message attachments (optional, must be an array)
+            "path/to/file", // Attachment item can be string (file location)
+
+            // Or can be an object for attachment detail
+            {
+                path: "path/to/file", // File location (Not optional, must be string)
+                name: "custom-file-name.jpg", // File name (optional, must be string) (Default is base name of file)
+                description: "File description" // Attachment description (optional, must be string) (Default is empty)
+            }
+        ],
     }
 );
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "author": "Sopur",
   "license": "GNU",
   "dependencies": {
+    "form-data": "^4.0.0",
     "node-fetch": "^2.6.7",
     "ws": "^8.3.0"
   }

--- a/src/client.js
+++ b/src/client.js
@@ -389,8 +389,6 @@ class Client {
                 } else {
                     res(response);
                 }
-            }).catch((err) => {
-                console.log("[ERR]", err.stack);
             });
         });
     }

--- a/src/client.js
+++ b/src/client.js
@@ -373,6 +373,7 @@ class Client {
                     "sec-fetch-mode": "cors",
                     "sec-fetch-site": "same-origin",
                     "x-discord-locale": this.config.language,
+                    ...(options.isMultipartFormData ? options.body.getHeaders() : {}),
                 },
                 referrer: `https://discord.com/channels/@me`,
                 referrerPolicy: "no-referrer-when-downgrade",
@@ -388,6 +389,8 @@ class Client {
                 } else {
                     res(response);
                 }
+            }).catch((err) => {
+                console.log("[ERR]", err.stack);
             });
         });
     }
@@ -508,6 +511,7 @@ class Client {
         this.call_check(arguments);
         data = new constructs.SendMessage(data);
         return await this.fetch_request(`channels/${channel_id}/messages`, {
+            isMultipartFormData: data.isMultipartFormData,
             body: data.content,
             method: "POST",
             parse: true,


### PR DESCRIPTION
Fix https://github.com/Sopur/Discord-user-bots/issues/22

How to use?
```js
client.send(
    "794326789480120374", // Channel to send in
    {
        content: "Hello Discord-user-bots!", // Content of the message to send (Optional when sending stickers) (Default null)
        reply: "914533507890565221", // Reply to the message ID given with this message (Optional) (Default null)
        tts: false, // Use text to speech when sending (Only works if you have the permissions to do so) (Optional) (Default false)
        embeds: [], // Embeds to send with your message (Not optional, must be an array, can be unset for default) (Default empty array)
        allowed_mentions: {
            // Allow mentions settings (Not optional, but can be unset for default) (Default all true mentions object)
            allowUsers: true, // Allow message to ping user (Default true)
            allowRoles: true, // Allow message to ping roles (Default true)
            allowEveryone: true, // Allow message to ping @everyone and @here (Default true)
            allowRepliedUser: true, // If the message is a reply, ping the user you are replying to (Default true)
        },
        components: [], // Message components (Not optional, must be an array, can be unset for default) (Default empty array)
        stickers: [], // Stickers to go with your message (Not optional, must be an array, can be unset for default) (Default empty array),
        attachments: [
                "path/to/file1",
                {
                        "path": "path/to/file2",
                        "name": "Custom File Name",
                        "description": "File description"
                },
                ...
        ],
    }
);
```