### PR TITLE
feat(reaction): add remove reaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ client.add_reaction(
     "🤖" // Emoji to react with (Cannot be ":robot:" has to be an actual emoji like "🤖")
 );
 
+// Remove a reaction to a message
+client.remove_reaction(
+    "914533528245506068", // The message to remove a reaction to
+    "753267478943105028", // The channel the message is in
+    "🤖" // Emoji to react with (Cannot be ":robot:" has to be an actual emoji like "🤖")
+);
+
 // Changes your visibility
 client.change_status(
     "online" // Status to change to (Must be "online", "idle", "dnd", or "invisible")

--- a/src/client.js
+++ b/src/client.js
@@ -736,6 +736,22 @@ class Client {
     }
 
     /**
+     * Remove a reaction to a message
+     * @param {string} message_id The message to remove a reaction to
+     * @param {string} channel_id The channel the message is in
+     * @param {string} emoji Emoji to react with (Cannot be ":robot:" has to be an actual emoji like "🤖")
+     * @returns {Promise<Object>} The response from Discord
+     */
+     async remove_reaction(message_id, channel_id, emoji) {
+        this.call_check(arguments);
+        return await this.fetch_request(`channels/${channel_id}/messages/${message_id}/reactions/${encodeURI(emoji)}/%40me`, {
+            body: null,
+            method: "DELETE",
+            parse: false,
+        });
+    }
+
+    /**
      * Changes your visibility
      * @param {"online" | "idle" | "dnd" | "invisible"} status Status to change to (Must be "online", "idle", "dnd", or "invisible")
      * @returns {Promise<Object>} The response from Discord


### PR DESCRIPTION
Fix: https://github.com/Sopur/Discord-user-bots/issues/24

How to use:
```js
client.remove_reaction(
    "914533528245506068", // The message to remove a reaction to
    "753267478943105028", // The channel the message is in
    "🤖" // Emoji to react with (Cannot be ":robot:" has to be an actual emoji like "🤖")
);
```